### PR TITLE
make support mail link dynamic

### DIFF
--- a/resources/views/error.blade.php
+++ b/resources/views/error.blade.php
@@ -23,7 +23,7 @@
                     <hr>
                     <p class="text-gray-600 my-2"> If you need further assistance, please contact us at <a
                             class="text-blue-500"
-                            href="mailto:{{config('payment-gateways.support_email')}}">support@pay4me.app</a> or reach
+                            href="mailto:{{$support_mail = config('payment-gateways.support_email')}}">{{ $support_mail }}</a> or reach
                         out to us via our social media
                         platforms.
                     </p>

--- a/resources/views/status.blade.php
+++ b/resources/views/status.blade.php
@@ -55,7 +55,7 @@
                     <hr>
                     <p class="text-gray-600 my-2"> If you need further assistance, please contact us at <a
                             class="text-blue-500"
-                            href="mailto:{{config('payment-gateways.support_email')}}">support@pay4me.app</a> or reach
+                            href="mailto:{{$support_mail = config('payment-gateways.support_email')}}">{{ $support_mail }}</a> or reach
                         out to us via our social media
                         platforms.
                     </p>


### PR DESCRIPTION
This fixes the support email link on the 'payment success' page reflect what has been set in the configuration.